### PR TITLE
npm start sets environment to local, defaults to production otherwise

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "The Way of the Exploding Keys",
   "main": "server/index.js",
   "scripts": {
+    "start": "NODE_ENV='local' node server/index.js",
     "test": "gulp test"
   },
   "repository": {

--- a/server/index.js
+++ b/server/index.js
@@ -25,7 +25,7 @@ app.get('/', function(req, res) {
 });
 
 app.get('/ip', function(req, res) {
-    var env = process.env.NODE_ENV;
+    var env = getEnvironment();
     var ipToReturn = ip;
     if (!env || env !== 'local') {
         ipToReturn = '52.17.219.89';
@@ -43,6 +43,8 @@ app.get('/status', function(req, res) {
 
 server = http.listen(3000, function() {
     var port = server.address().port;
+    var environment = getEnvironment();
+    console.log('Environment: %s', environment);
     console.log('TWOTEK app is listening at %s', port);
 });
 
@@ -148,6 +150,9 @@ function handlePlayerNotAdded(socket) {
     };
 }
 
+function getEnvironment() {
+    return process.env.NODE_ENV || 'production';
+}
 
 function logSocketMsg(msgTitle) {
     console.log('received socket message: **' + msgTitle + '**');


### PR DESCRIPTION
Yo,

Potential fix for NODE_ENV worries.

I've added a `start` command to package.json, so we can now run the local server via npm by doing `npm start`. This will mean that if we just use node server/index.js it will default to production mode.
